### PR TITLE
TypeError  Argument 1 passed to h4kuna\Ares\Ares::exists()

### DIFF
--- a/src/Ares.php
+++ b/src/Ares.php
@@ -170,8 +170,11 @@ class Ares
 	}
 
 
-	private static function exists(\SimpleXMLElement $element, string $property): string
+	private static function exists(?\SimpleXMLElement $element, string $property): string
 	{
+	    if ($element === null) {
+	        return '';
+        }
 		return isset($element->{$property}) ? ((string) $element->{$property}) : '';
 	}
 


### PR DESCRIPTION
TypeError

Argument 1 passed to h4kuna\Ares\Ares::exists() must be an instance of SimpleXMLElement, null given.

![image](https://user-images.githubusercontent.com/7610662/110907599-f00b0680-830d-11eb-9e0e-58d30608753f.png)
