### PR TITLE
PHP 8.4: Implicitly nullable parameter declarations deprecated

### DIFF
--- a/src/Exceptions/ConnectionException.php
+++ b/src/Exceptions/ConnectionException.php
@@ -18,7 +18,7 @@ class ConnectionException extends \RuntimeException implements ClientExceptionIn
 	public function __construct(
 		$message = 'The service is probably overloaded. Repeat request after a few minutes.',
 		$code = 0,
-		\Throwable $previous = null,
+		?\Throwable $previous = null,
 	)
 	{
 		parent::__construct($message, $code, $previous);

--- a/src/Exceptions/IdentificationNumberNotFoundException.php
+++ b/src/Exceptions/IdentificationNumberNotFoundException.php
@@ -10,7 +10,7 @@ final class IdentificationNumberNotFoundException extends AresException
 	private string $in;
 
 
-	public function __construct(string $message = '', string $in = '', Throwable $previous = null)
+	public function __construct(string $message = '', string $in = '', ?Throwable $previous = null)
 	{
 		parent::__construct($message, $previous === null ? 0 : $previous->getCode(), $previous);
 		$this->in = $in;

--- a/src/Exceptions/ServerResponseException.php
+++ b/src/Exceptions/ServerResponseException.php
@@ -12,7 +12,7 @@ final class ServerResponseException extends ConnectionException
 	public function __construct(
 		$message = 'The service is probably overloaded. Repeat request after a few minutes.',
 		$code = 0,
-		\Throwable $previous = null,
+		?\Throwable $previous = null,
 	)
 	{
 		parent::__construct($message, $code, $previous);


### PR DESCRIPTION
Closes #43 